### PR TITLE
Add a minimal pyproject.toml file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -1,23 +1,21 @@
 import setuptools
-import re
-
-name = 'molecule-proxmox'
-description='Proxmox Molecule Plugin :: run molecule tests using proxmox'
-
-def find_version():
-    text = open('src/%s/__init__.py' % name.replace('-', '_')).read()
-    return re.search(r"__version__\s*=\s*'(.*)'", text).group(1)
 
 setuptools.setup(
-    name=name,
-    version=find_version(),
+    name='molecule-proxmox',
+    version='1.1.0',
     author='Michael Meffie',
     author_email='mmeffie@sinenomine.net',
-    description=description,
+    description='Proxmox Molecule Plugin :: run molecule tests using proxmox',
     long_description=open('README.rst').read(),
     long_description_content_type='text/x-rst',
     url='https://github.com/meffie/molecule-proxmox',
-    packages=setuptools.find_packages(where='src'),
+    packages=[
+        'molecule_proxmox',
+        'molecule_proxmox.cookiecutter',
+        'molecule_proxmox.modules',
+        'molecule_proxmox.playbooks',
+        'molecule_proxmox.playbooks.common',
+    ],
     package_dir={'': 'src'},
     include_package_data=True,
     entry_points={

--- a/tox.ini
+++ b/tox.ini
@@ -163,12 +163,24 @@ commands =
     sphinx-build -M html source build
 
 #
+# Usage:  tox -e build
+#
+[testenv:build]
+description = Build python package
+basepython = python3
+deps =
+    build==1.2.2
+commands =
+    python -m build
+
+#
 # Usage:  tox -e release
 #
 # Note: Set TWINE env vars or ~/.pypirc before running.
 #
 [testenv:release]
-basepython = python3.12
+description = Upload release to pypi
+basepython = python3
 passenv =
     TWINE_USERNAME
     TWINE_PASSWORD


### PR DESCRIPTION
Add a pyproject.toml file in the project root directory, since this is expected by modern python packaging tools.  Add a minimal configuration as shown in the setuptools documentation.

Keep setup.py for now, since setuptools still supports it as a first class configuration file, but remove the dynamically generated configuration from setup.py, except for the code to read the README.rst. The long desription in used to create the PyPI project page, and so we use the same test as the readme.

Add the `tox -e build` developer task to build the package using the modern python -m build method.

Add a description setting to the `tox -e release` task.