### PR TITLE
Replace community.general with community.proxmox

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,12 +12,12 @@ Requirements
 * Access to a `Proxmox VE`_ cluster
 * One or more virtual machine templates with required setup
 * Python package `proxmoxer`_
-* Ansible module `community.general.proxmox_kvm`_
+* Ansible module `community.proxmox.proxmox_kvm`_
 
 The required Python packages are automatically installed when
 ``molecule-proxmox`` is installed with ``pip``.
 
-The ``proxmox_kvm`` module is included with the Community.General collection
+The ``proxmox_kvm`` module is included with the Community.Proxmox collection
 and is automatically installed when Ansible is installed with ``pip``.
 
 
@@ -247,5 +247,5 @@ The `MIT`_ License.
 
 .. _`Proxmox VE`: https://www.proxmox.com/en/proxmox-ve
 .. _`proxmoxer`: https://pypi.org/project/proxmoxer/
-.. _`community.general.proxmox_kvm`: https://docs.ansible.com/ansible/latest/collections/community/general/proxmox_kvm_module.html
+.. _`community.proxmox.proxmox_kvm`: https://docs.ansible.com/ansible/latest/collections/community/proxmox/proxmox_kvm_module.html
 .. _`MIT`: https://github.com/meffie/molecule-proxmox/blob/master/LICENSE

--- a/src/molecule_proxmox/playbooks/create.yml
+++ b/src/molecule_proxmox/playbooks/create.yml
@@ -11,7 +11,7 @@
       when: options.proxmox_secrets is defined
 
     - name: "Create molecule instance(s)."
-      community.general.proxmox_kvm:
+      community.proxmox.proxmox_kvm:
         state: present
         api_host: "{{ api_host | d(options.api_host) | d(omit) }}"
         api_port: "{{ api_port | d(options.api_port) | d(omit) }}"
@@ -34,7 +34,7 @@
       register: proxmox_clone
 
     - name: "Update molecule instance config(s)"
-      community.general.proxmox_kvm:
+      community.proxmox.proxmox_kvm:
         state: present
         update: true
         api_host: "{{ api_host | d(options.api_host) | d(omit) }}"

--- a/src/molecule_proxmox/playbooks/destroy.yml
+++ b/src/molecule_proxmox/playbooks/destroy.yml
@@ -27,7 +27,7 @@
       when: not instance_config_stat.stat.exists
 
     - name: "Remove molecule instance(s)."
-      community.general.proxmox_kvm:
+      community.proxmox.proxmox_kvm:
         api_host: "{{ api_host | d(options.api_host) | d(omit) }}"
         api_port: "{{ api_port | d(options.api_port) | d(omit) }}"
         api_user: "{{ api_user | d(options.api_user) | d(omit) }}"


### PR DESCRIPTION
As of the community.general release 10.7.0 community.general dropped the support for the proxmox modules. See https://github.com/ansible-collections/community.general/blob/stable-10/CHANGELOG.md#deprecated-features. Instead, we need to use community.proxmox.proxmox_kvm. Users will run into problems, when they either try using community.general >=10.6.0 or come with ansible-core 2.19 / Ansible>=12.